### PR TITLE
Removed duplicate of '/v1' in uri on topic subscribing and unsubcribing

### DIFF
--- a/src/AGConnectAdmin/Messaging/AGConnectMessagingClient.cs
+++ b/src/AGConnectAdmin/Messaging/AGConnectMessagingClient.cs
@@ -163,7 +163,7 @@ namespace AGConnectAdmin.Messaging
                 Topic = topic,
                 Tokens = new List<string>(registrationTokens)
             };
-            var url = $"{options.ApiBaseUri}/v1/{options.ClientId}/topic:subscribe";
+            var url = $"{options.ApiBaseUri}/{options.ClientId}/topic:subscribe";
             var payload = NewtonsoftJsonSerializer.Instance.Serialize(body);
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
             var request = new HttpRequestMessage()
@@ -213,7 +213,7 @@ namespace AGConnectAdmin.Messaging
                 Topic = topic,
                 Tokens = new List<string>(registrationTokens)
             };
-            var url = $"{options.ApiBaseUri}/v1/{options.ClientId}/topic:unsubscribe";
+            var url = $"{options.ApiBaseUri}/{options.ClientId}/topic:unsubscribe";
             var payload = NewtonsoftJsonSerializer.Instance.Serialize(body);
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
             var request = new HttpRequestMessage()
@@ -247,7 +247,7 @@ namespace AGConnectAdmin.Messaging
             {
                 Token = registrationToken
             };
-            var url = $"{options.ApiBaseUri}/v1/{options.ClientId}/topic:list";
+            var url = $"{options.ApiBaseUri}/{options.ClientId}/topic:list";
             var payload = NewtonsoftJsonSerializer.Instance.Serialize(body);
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
             var request = new HttpRequestMessage()


### PR DESCRIPTION
Fixing duplicate of `/v1`in URI when subscribing/unsubscribing to a topic. 

When configuring `AGConnectApp` with `ApiBaseUri` the default value of the URI already contains `/v1`, and since it was present in the URI:s methods `SubscribeToTopicAsync` and `UnsubscribeFromTopicAsync` we were left with duplicates which points us to the wrong resource, eg `[...]/v1/v1/[ClientId]/subscribe:topic`.

This fix removes the duplicate of `/v1` to point us to the correct resource.